### PR TITLE
github: add support for GitHub Enterprise

### DIFF
--- a/github.tf
+++ b/github.tf
@@ -8,6 +8,7 @@ resource "tls_private_key" "flux" {
 
 provider "github" {
   organization = "${var.github_org_name}"
+  base_url     = "${var.github_base_url}"
 }
 
 data "github_repository" "flux-repo" {

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,10 @@ variable "eks_cluster_name" {
   description = "Name of the EKS cluster upon which to configure Flux"
 }
 
+variable "github_base_url" {
+  description = "This is the target GitHub base API endpoint. Providing a value is a requirement when working with GitHub Enterprise."
+  default     = null
+}
 variable "github_org_name" {
   description = "Name of the Github Organisation"
 }


### PR DESCRIPTION
We'd like to use this module, but we use GitHub Enterprise.

This PR adds support for the base_url parameter.