### PR TITLE
Additional Flux Arguments, Docker Registry update

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -15,8 +15,20 @@ variable "github_repository_name" {
   description = "Name of the Github repository for Flux"
 }
 
+variable "github_repository_branch" {
+  description = "Branch to use as the upstream GitOps reference"
+  type        = string
+  default     = "master"
+}
+
 variable "flux_known_hosts" {
   description = "Set of hosts and their public ssh keys to mount into `/root/.ssh/known_hosts`"
   type        = set(string)
   default     = []
+}
+
+variable "flux_args_extra" {
+  description = "Mapping of additional arguments to provide to the flux daemon"
+  type        = map(string)
+  default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "github_repository_branch" {
   default     = "master"
 }
 
+variable "flux_docker_tag" {
+  description = "Tag of flux Docker image to pull"
+  type        = string
+  default     = "1.10.1"
+}
+
 variable "flux_known_hosts" {
   description = "Set of hosts and their public ssh keys to mount into `/root/.ssh/known_hosts`"
   type        = set(string)

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,7 @@ variable "github_repository_branch" {
 variable "flux_docker_tag" {
   description = "Tag of flux Docker image to pull"
   type        = string
-  default     = "1.10.1"
+  default     = "1.17.1"
 }
 
 variable "flux_known_hosts" {

--- a/variables.tf
+++ b/variables.tf
@@ -14,3 +14,9 @@ variable "github_org_name" {
 variable "github_repository_name" {
   description = "Name of the Github repository for Flux"
 }
+
+variable "flux_known_hosts" {
+  description = "Set of hosts and their public ssh keys to mount into `/root/.ssh/known_hosts`"
+  type        = set(string)
+  default     = []
+}

--- a/weave_flux_bootstrap.tf
+++ b/weave_flux_bootstrap.tf
@@ -152,7 +152,7 @@ resource "kubernetes_deployment" "flux" {
 
         container {
           name  = "flux"
-          image = "quay.io/weaveworks/flux:1.10.1"
+          image = "weaveworks/flux:1.10.1"
 
           # See the following GH issue for why we have to do this manually
           # https://github.com/terraform-providers/terraform-provider-kubernetes/issues/38

--- a/weave_flux_bootstrap.tf
+++ b/weave_flux_bootstrap.tf
@@ -179,7 +179,7 @@ resource "kubernetes_deployment" "flux" {
 
         container {
           name  = "flux"
-          image = "weaveworks/flux:${var.flux_docker_tag}"
+          image = "docker.io/fluxcd/flux:${var.flux_docker_tag}"
 
           # See the following GH issue for why we have to do this manually
           # https://github.com/terraform-providers/terraform-provider-kubernetes/issues/38

--- a/weave_flux_bootstrap.tf
+++ b/weave_flux_bootstrap.tf
@@ -134,6 +134,7 @@ resource "kubernetes_deployment" "flux" {
     template {
       metadata {
         labels = {
+          app = "flux"
           name = "flux"
         }
       }

--- a/weave_flux_bootstrap.tf
+++ b/weave_flux_bootstrap.tf
@@ -178,7 +178,7 @@ resource "kubernetes_deployment" "flux" {
 
         container {
           name  = "flux"
-          image = "weaveworks/flux:1.10.1"
+          image = "weaveworks/flux:${var.flux_docker_tag}"
 
           # See the following GH issue for why we have to do this manually
           # https://github.com/terraform-providers/terraform-provider-kubernetes/issues/38


### PR DESCRIPTION
# flux: use dockerhub instead of quay.io
1151182 - 7331206+chrised@users.noreply.github.com

The image appears to have moved.

Error message:
`Failed to pull image "quay.io/weaveworks/flux:1.10.1": rpc error: code
= Unknown desc = Error response from daemon: Get
https://quay.io/v2/weaveworks/flux/manifests/1.10.1: denied: Namespace
weaveworks has been disabled. Please contact a system administrator.`

# flux: add optional known_hosts ConfigMap definition
bc67adb - 7331206+chrised@users.noreply.github.com


# flux: add mapping for additional arguments
fb5e812 - 7331206+chrised@users.noreply.github.com


# flux: add `flux_docker_tag` variable
694a09f - 7331206+chrised@users.noreply.github.com


# flux: re-add `app=flux` label
312144d - 7331206+chrised@users.noreply.github.com