### PR TITLE
tls: add option to provide an already-created private_key pemfile

### DIFF
--- a/github.tf
+++ b/github.tf
@@ -2,6 +2,7 @@
 # will be added as a deploy key to the Github repo.
 
 resource "tls_private_key" "flux" {
+  count     = var.private_key_pem == null ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = 2048
 }
@@ -16,9 +17,9 @@ data "github_repository" "flux-repo" {
 }
 
 resource "github_repository_deploy_key" "flux" {
+  count      = var.private_key_pem == null ? 1 : 0
   title      = "Flux deploy key (eks-${var.eks_cluster_name})"
   repository = data.github_repository.flux-repo.name
   read_only  = false
-  key        = tls_private_key.flux.public_key_openssh
+  key        = tls_private_key.flux[0].public_key_openssh
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -38,3 +38,9 @@ variable "flux_args_extra" {
   type        = map(string)
   default     = {}
 }
+
+variable "private_key_pem" {
+  description = "Alternative Private Key for Flux to use when polling git via ssh"
+  type        = string
+  default     = null
+}

--- a/weave_flux_bootstrap.tf
+++ b/weave_flux_bootstrap.tf
@@ -232,7 +232,7 @@ resource "kubernetes_secret" "flux-git-deploy" {
   type = "Opaque"
 
   data = {
-    identity = tls_private_key.flux.private_key_pem
+    identity = length(tls_private_key.flux) > 0 ? tls_private_key.flux[0].private_key_pem : var.private_key_pem
   }
 
   depends_on = [kubernetes_namespace.flux]


### PR DESCRIPTION
I've tested this by deploying with and without a key specified.

Storing our private key in Terraform's state is suboptimal from a security standpoint, so we'd rather avoid it by providing one we've read from secure storage :)