### PR TITLE
root_sshdir should depend on the namespace resource

### DIFF
--- a/weave_flux_bootstrap.tf
+++ b/weave_flux_bootstrap.tf
@@ -112,6 +112,10 @@ resource "kubernetes_config_map" "root_sshdir" {
   data = {
     "known_hosts" = join("\n", var.flux_known_hosts)
   }
+
+  depends_on = [
+    kubernetes_namespace.flux,
+  ]
 }
 
 resource "kubernetes_deployment" "flux" {


### PR DESCRIPTION
Currently it is possible to run into trouble like this: 

```
Error: namespaces "flux" not found

  on .terraform/modules/flux-bootstrap/weave_flux_bootstrap.tf line 103, in resource "kubernetes_config_map" "root_sshdir":
 103: resource "kubernetes_config_map" "root_sshdir" {
```