### PR TITLE
Adding vars for flux deployment annotations + labels

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,24 @@ variable "deploy_memcached" {
   type        = bool
   default     = true
 }
+
+variable "flux_deployment_annotations" {
+  description = "Optional annotations to apply to the Flux deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "flux_deployment_labels" {
+  description = "Optional labels to apply to the Flux deployment"
+  type        = map(string)
+  default = {
+    app  = "flux"
+    name = "flux"
+  }
+}
+
+variable "memcached_docker_tag" {
+  description = "Tag of memcached Docker image to pull"
+  type        = string
+  default     = "1.4.25"
+}

--- a/weave_flux_bootstrap.tf
+++ b/weave_flux_bootstrap.tf
@@ -122,10 +122,7 @@ resource "kubernetes_deployment" "flux" {
   metadata {
     name      = "flux"
     namespace = local.k8s-ns
-    labels = {
-      app  = "flux"
-      name = "flux"
-    }
+    labels    = var.flux_deployment_labels
   }
 
   spec {
@@ -141,10 +138,8 @@ resource "kubernetes_deployment" "flux" {
 
     template {
       metadata {
-        labels = {
-          app  = "flux"
-          name = "flux"
-        }
+        labels      = var.flux_deployment_labels
+        annotations = var.flux_deployment_annotations
       }
 
       spec {
@@ -271,7 +266,7 @@ resource "kubernetes_deployment" "memcached" {
       spec {
         container {
           name  = "memcached"
-          image = "memcached:1.4.25"
+          image = "memcached:${var.memcached_docker_tag}"
 
           port {
             name           = "clients"


### PR DESCRIPTION
To allow for custom annotations/labels to be defined for the Flux deployment, this change exposes a map variable for each.