### PR TITLE
Properly support user provided private key

### DIFF
--- a/github.tf
+++ b/github.tf
@@ -7,19 +7,24 @@ resource "tls_private_key" "flux" {
   rsa_bits  = 2048
 }
 
+data "tls_public_key" "user_provided" {
+  count           = var.private_key_pem == null ? 0 : 1
+  private_key_pem = var.private_key_pem
+}
+
 data "github_repository" "flux-repo" {
   count     = var.github_install_deploy_key == true ? 1 : 0
   full_name = "${var.github_repository_owner}/${var.github_repository_name}"
 }
 
 resource "github_repository_deploy_key" "flux" {
-  count      = var.private_key_pem == null ? (var.github_install_deploy_key == true ? 1 : 0) : (0)
+  count      = var.github_install_deploy_key == true ? 1 : 0
   title      = var.github_deploy_key_title
   repository = data.github_repository.flux-repo[0].name
   read_only  = false
-  key        = tls_private_key.flux[0].public_key_openssh
+  key        = length(tls_private_key.flux) > 0 ? tls_private_key.flux[0].public_key_openssh : data.tls_public_key.user_provided[0].public_key_openssh
 }
 
 output "public_key_openssh" {
-  value = tls_private_key.flux[0].public_key_openssh
+  value = length(tls_private_key.flux) > 0 ? tls_private_key.flux[0].public_key_openssh : data.tls_public_key.user_provided[0].public_key_openssh
 }

--- a/github.tf
+++ b/github.tf
@@ -12,15 +12,10 @@ data "tls_public_key" "user_provided" {
   private_key_pem = var.private_key_pem
 }
 
-data "github_repository" "flux-repo" {
-  count     = var.github_install_deploy_key == true ? 1 : 0
-  full_name = "${var.github_repository_owner}/${var.github_repository_name}"
-}
-
 resource "github_repository_deploy_key" "flux" {
   count      = var.github_install_deploy_key == true ? 1 : 0
   title      = var.github_deploy_key_title
-  repository = data.github_repository.flux-repo[0].name
+  repository = var.github_repository_name
   read_only  = false
   key        = length(tls_private_key.flux) > 0 ? tls_private_key.flux[0].public_key_openssh : data.tls_public_key.user_provided[0].public_key_openssh
 }

--- a/github.tf
+++ b/github.tf
@@ -12,10 +12,15 @@ data "tls_public_key" "user_provided" {
   private_key_pem = var.private_key_pem
 }
 
+data "github_repository" "flux-repo" {
+  count     = var.github_install_deploy_key == true ? 1 : 0
+  full_name = "${var.github_repository_owner}/${var.github_repository_name}"
+}
+
 resource "github_repository_deploy_key" "flux" {
   count      = var.github_install_deploy_key == true ? 1 : 0
   title      = var.github_deploy_key_title
-  repository = var.github_repository_name
+  repository = data.github_repository.flux-repo[0].name
   read_only  = false
   key        = length(tls_private_key.flux) > 0 ? tls_private_key.flux[0].public_key_openssh : data.tls_public_key.user_provided[0].public_key_openssh
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,11 +3,6 @@ variable "github_repository_name" {
   type        = string
 }
 
-variable "github_repository_owner" {
-  description = "Org or user ID of the repo owner"
-  type        = string
-}
-
 variable "github_repository_branch" {
   description = "Branch to use as the upstream GitOps reference"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,11 @@ variable "github_repository_name" {
   type        = string
 }
 
+variable "github_repository_owner" {
+  description = "Org or user ID of the repo owner"
+  type        = string
+}
+
 variable "github_repository_branch" {
   description = "Branch to use as the upstream GitOps reference"
   type        = string


### PR DESCRIPTION
This change will allow the public key to be added to the GitHub
repo even if the private key is provided by the user and not
generated by the module.