### PR TITLE
add memcache max cache size value to runtime args

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -51,13 +51,7 @@ variable "deploy_memcached" {
   default     = true
 }
 
-variable "staging_memcache_max_item_size"{
-  description = "the max item size allowed in the staging memcached deployment"
-  type = string
-  default = "5m"
-}
-
-variable "prod_memcache_max_item_size"{
+variable "memcache_max_item_size"{
   description = "the max item size allowed in the staging memcached deployment"
   type = string
   default = "5m"

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,18 @@ variable "deploy_memcached" {
   default     = true
 }
 
+variable "staging_memcache_max_item_size"{
+  description = "the max item size allowed in the staging memcached deployment"
+  type = string
+  default = "5m"
+}
+
+variable "prod_memcache_max_item_size"{
+  description = "the max item size allowed in the staging memcached deployment"
+  type = string
+  default = "5m"
+}
+
 variable "flux_deployment_annotations" {
   description = "Optional annotations to apply to the Flux deployment"
   type        = map(string)

--- a/weave_flux_bootstrap.tf
+++ b/weave_flux_bootstrap.tf
@@ -318,8 +318,8 @@ resource "kubernetes_deployment" "memcached" {
             container_port = 11211
           }
           args = concat([
-            "-I 5m",
-          ],
+            "-I 5m"
+          ])
         }
       }
     }

--- a/weave_flux_bootstrap.tf
+++ b/weave_flux_bootstrap.tf
@@ -317,6 +317,9 @@ resource "kubernetes_deployment" "memcached" {
             name           = "clients"
             container_port = 11211
           }
+          args = concat([
+            "-I 5m",
+          ],
         }
       }
     }

--- a/weave_flux_bootstrap.tf
+++ b/weave_flux_bootstrap.tf
@@ -23,6 +23,8 @@ locals {
     for key in keys(var.flux_args_extra) :
     "--${key}=${var.flux_args_extra[key]}"
   ]
+  staging_memcache_max_item_size = "-I 5m"
+  prod_memcache_max_item_size = "-I 5m"
 }
 
 resource "kubernetes_namespace" "flux" {
@@ -317,9 +319,7 @@ resource "kubernetes_deployment" "memcached" {
             name           = "clients"
             container_port = 11211
           }
-          args = concat([
-            "-I 5m"
-          ])
+          args = local.staging_memcache_max_size
         }
       }
     }

--- a/weave_flux_bootstrap.tf
+++ b/weave_flux_bootstrap.tf
@@ -317,7 +317,7 @@ resource "kubernetes_deployment" "memcached" {
             name           = "clients"
             container_port = 11211
           }
-          args = "-I ${var.staging_memcache_max_size}"
+          args = "-I ${var.memcache_max_item_size}"
         }
       }
     }

--- a/weave_flux_bootstrap.tf
+++ b/weave_flux_bootstrap.tf
@@ -23,8 +23,6 @@ locals {
     for key in keys(var.flux_args_extra) :
     "--${key}=${var.flux_args_extra[key]}"
   ]
-  staging_memcache_max_item_size = "-I 5m"
-  prod_memcache_max_item_size = "-I 5m"
 }
 
 resource "kubernetes_namespace" "flux" {
@@ -319,7 +317,7 @@ resource "kubernetes_deployment" "memcached" {
             name           = "clients"
             container_port = 11211
           }
-          args = local.staging_memcache_max_size
+          args = "-I ${var.staging_memcache_max_size}"
         }
       }
     }


### PR DESCRIPTION
update deployment to include max cache size in rutime args as suggested in this issue: https://github.com/fluxcd/flux/issues/1720. 5m seems to be an accepted value. I've written a single arg but in a list with the `concat` formatting so that it is easy to add additional arguments in the future if needed.